### PR TITLE
 Fixes: Resolved Course Card Overlap with Navigation Bar  

### DIFF
--- a/navigateToPages/services.html
+++ b/navigateToPages/services.html
@@ -56,6 +56,7 @@ gap: 20px;
 height: 1089px;
 margin-top: 12px;
 background:  #ebf6f5 ;
+padding: 20px;
 }
 .btn-primary{
 background: #5cbdb9;

--- a/style.css
+++ b/style.css
@@ -131,7 +131,7 @@ html,body{
     border-radius: 8px;
     outline: none;
     background-color:whitesmoke;
-    color: white;
+    /* color: white; */
     transition: .3s ease;
    }
    


### PR DESCRIPTION
**Description:**  
This pull request addresses the issue where course cards on the courses page overlapped with the navigation bar when hovered over. 

Fixes #83 

**Testing Done:**  
- Verified that the course cards no longer overlap with the navigation bar on hover.  
<img width="595" alt="overlap-card-fix" src="https://github.com/user-attachments/assets/a41ed9fb-396a-4e8e-8f6e-6cd262eab322" />
